### PR TITLE
Add support for embedded-hal-async

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,5 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Build
+      run: cargo build --verbose --features async

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,12 @@ repository = "https://github.com/justinlatimer/ina226"
 bitflags = "2.4"
 byteorder = { version = "1", default-features = false }
 embedded-hal = "1.0"
+embedded-hal-async = { version = "1.0.0", optional = true }
+maybe-async-cfg = "0.2.3"
 
 [dev-dependencies]
 approx = "0.5"
 embedded-hal-mock = "0.10"
+
+[features]
+async = ["dep:embedded-hal-async"]


### PR DESCRIPTION
Allow the driver to be used both by async and sync code. The variant can be switched by using the `async` feature for async, while by default it will be sync.